### PR TITLE
Fix wrong SPI Host

### DIFF
--- a/epdif.cpp
+++ b/epdif.cpp
@@ -69,7 +69,7 @@ int EpdIf::IfInit(void) {
     if(spi) {
 		spi_bus_remove_device(spi);
 	}
-	spi_bus_free(VSPI_HOST);
+	spi_bus_free(SPI_HOST);
     
     gpio_config_t io_conf = {0};
     io_conf.intr_type = GPIO_INTR_DISABLE;
@@ -97,7 +97,7 @@ int EpdIf::IfInit(void) {
     buscfg.quadhd_io_num = -1;
 
     //Initialize the SPI bus
-    ret=spi_bus_initialize(HSPI_HOST, &buscfg, 0);
+    ret=spi_bus_initialize(SPI_HOST, &buscfg, 0);
     switch (ret) {
         case ESP_ERR_INVALID_ARG:
             ESP_LOGE("EPDIF", "INVALID ARG");
@@ -124,7 +124,7 @@ int EpdIf::IfInit(void) {
     devcfg.queue_size = 1;
 
     //Attach the EPD to the SPI bus
-    ret=spi_bus_add_device(HSPI_HOST, &devcfg, &spi);
+    ret=spi_bus_add_device(SPI_HOST, &devcfg, &spi);
     assert(ret==ESP_OK);
 
     return 0;

--- a/include/epdif.h
+++ b/include/epdif.h
@@ -47,6 +47,9 @@
 #define RST_PIN   CONFIG_RST_PIN         
 #define BUSY_PIN  CONFIG_BUSY_PIN        
 
+// SPI host
+#define SPI_HOST    HSPI_HOST
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Fix wrong SPI host used in spi_bus_free().

- Defined new macro, SPI_HOST, that refers to HSPI_HOST
- Replaced all host with the created macro